### PR TITLE
Fixed `rmdirEmpty()` throwing exceptions on symlinks.

### DIFF
--- a/File.php
+++ b/File.php
@@ -455,7 +455,7 @@ class File {
    *   Directory path to remove if empty.
    */
   public static function rmdirEmpty(string $directory): void {
-    if (is_dir($directory) && static::dirIsEmpty($directory)) {
+    if (is_dir($directory) && !is_link($directory) && static::dirIsEmpty($directory)) {
       static::rmdir($directory);
       static::rmdirEmpty(dirname($directory));
     }

--- a/tests/Unit/FileTest.php
+++ b/tests/Unit/FileTest.php
@@ -251,16 +251,29 @@ class FileTest extends UnitTestCase {
     $file = $dir . DIRECTORY_SEPARATOR . 'file.txt';
     file_put_contents($file, 'test');
 
+    // Create a symlink directory.
+    $symlink_target = $dir . DIRECTORY_SEPARATOR . 'symlink_target';
+    mkdir($symlink_target, 0777, TRUE);
+    $symlink_dir = $dir . DIRECTORY_SEPARATOR . 'symlink_dir';
+    symlink($symlink_target, $symlink_dir);
+
     $this->assertDirectoryExists($dir);
     $this->assertDirectoryExists($subdir);
+    $this->assertTrue(is_link($symlink_dir));
 
+    // Test that rmdirEmpty works on real directories but not on symlinks.
     File::rmdirEmpty($subdir);
     File::rmdirEmpty($subsubdir);
+    // Symlink should be skipped.
+    File::rmdirEmpty($symlink_dir);
 
     $this->assertDirectoryDoesNotExist($subdir);
     $this->assertDirectoryExists($dir);
     $this->assertDirectoryExists($this->testTmpDir);
+    // Symlink should still exist.
+    $this->assertTrue(is_link($symlink_dir));
 
+    // Clean up.
     File::rmdir($dir);
     $this->assertDirectoryDoesNotExist($dir);
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved directory removal to prevent accidental deletion of symbolic link directories.

- **Tests**
  - Enhanced tests to verify that symbolic link directories are not removed during directory cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->