### PR TITLE
Fixed `renameInDir()` not overwriting existing files.

### DIFF
--- a/File.php
+++ b/File.php
@@ -562,7 +562,7 @@ class File {
           static::mkdir($new_dir, 0777);
         }
 
-        (new Filesystem())->rename($filename, $new_filename);
+        (new Filesystem())->rename($filename, $new_filename, TRUE);
 
         static::rmdirEmpty(dirname($filename));
       }

--- a/tests/Unit/FileStringsTest.php
+++ b/tests/Unit/FileStringsTest.php
@@ -340,6 +340,29 @@ class FileStringsTest extends UnitTestCase {
     ];
   }
 
+  public function testRenameInDirOverwrite(): void {
+    $dir = $this->locationsFixtureDir('tokens');
+
+    $source_files = [
+      $dir . '/foo/foofoo_b.txt',
+      $dir . '/foobar_b.txt',
+    ];
+
+    File::mkdir(static::$sut . '/bar');
+    File::copy($source_files[0], static::$sut . '/foo/foofoo_b.txt');
+    File::copy($source_files[1], static::$sut . '/bar/barbar_b.txt');
+
+    $this->assertTrue(File::exists(static::$sut . '/foo/foofoo_b.txt'));
+    $this->assertTrue(File::exists(static::$sut . '/bar/barbar_b.txt'));
+    $this->assertTrue(File::contains(static::$sut . '/bar/barbar_b.txt', 'BAR'));
+
+    File::renameInDir(static::$sut, 'foo', 'bar');
+
+    $this->assertFileExists(static::$sut . '/bar/barbar_b.txt');
+    $this->assertTrue(File::contains(static::$sut . '/bar/barbar_b.txt', 'FOO'));
+    $this->assertFalse(File::contains(static::$sut . '/bar/barbar_b.txt', 'BAR'));
+  }
+
   protected function flattenFileTree(array $tree, string $parent = '.'): array {
     $flatten = [];
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved file renaming to overwrite existing files when a name conflict occurs.

- **Tests**
  - Added a test to verify that files are correctly overwritten during the rename operation when a file with the target name already exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->