### PR TITLE
Moved `ExtendedSplFileInfo` out of `Internal` namespace.

### DIFF
--- a/File.php
+++ b/File.php
@@ -7,13 +7,12 @@ namespace AlexSkrypnyk\File;
 use AlexSkrypnyk\File\Exception\FileException;
 use AlexSkrypnyk\File\Internal\Comparer;
 use AlexSkrypnyk\File\Internal\Diff;
-use AlexSkrypnyk\File\Internal\ExtendedSplFileInfo;
-use AlexSkrypnyk\File\Internal\Tasker;
 use AlexSkrypnyk\File\Internal\Index;
 use AlexSkrypnyk\File\Internal\Patcher;
 use AlexSkrypnyk\File\Internal\Rules;
 use AlexSkrypnyk\File\Internal\Strings;
 use AlexSkrypnyk\File\Internal\Syncer;
+use AlexSkrypnyk\File\Internal\Tasker;
 use Symfony\Component\Filesystem\Filesystem;
 
 class File {

--- a/README.md
+++ b/README.md
@@ -47,9 +47,7 @@ multiple files efficiently.
 All methods are available through the `AlexSkrypnyk\File\File` class.
 
 ```php
-use AlexSkrypnyk\File\File;
-use AlexSkrypnyk\File\Exception\FileException;
-use AlexSkrypnyk\File\Internal\ExtendedSplFileInfo;
+use AlexSkrypnyk\File\Exception\FileException;use AlexSkrypnyk\File\ExtendedSplFileInfo;use AlexSkrypnyk\File\File;
 
 try {
   // Get current working directory
@@ -146,8 +144,7 @@ traditional file operations:
 #### Usage Example
 
 ```php
-use AlexSkrypnyk\File\File;
-use AlexSkrypnyk\File\Internal\ExtendedSplFileInfo;
+use AlexSkrypnyk\File\ExtendedSplFileInfo;use AlexSkrypnyk\File\File;
 
 // Traditional approach (slow for multiple operations)
 File::replaceContentInDir('/path/to/dir', 'old1', 'new1');

--- a/src/ExtendedSplFileInfo.php
+++ b/src/ExtendedSplFileInfo.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace AlexSkrypnyk\File\Internal;
+namespace AlexSkrypnyk\File;
 
 use AlexSkrypnyk\File\Exception\FileException;
 

--- a/src/Internal/Diff.php
+++ b/src/Internal/Diff.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AlexSkrypnyk\File\Internal;
 
+use AlexSkrypnyk\File\ExtendedSplFileInfo;
 use SebastianBergmann\Diff\Differ;
 use SebastianBergmann\Diff\Output\UnifiedDiffOutputBuilder;
 
@@ -27,7 +28,7 @@ class Diff implements RenderInterface {
   /**
    * Sets the left (source) file.
    *
-   * @param \AlexSkrypnyk\File\Internal\ExtendedSplFileInfo $file
+   * @param \AlexSkrypnyk\File\ExtendedSplFileInfo $file
    *   The file to set.
    *
    * @return $this
@@ -42,7 +43,7 @@ class Diff implements RenderInterface {
   /**
    * Sets the right (destination) file.
    *
-   * @param \AlexSkrypnyk\File\Internal\ExtendedSplFileInfo $file
+   * @param \AlexSkrypnyk\File\ExtendedSplFileInfo $file
    *   The file to set.
    *
    * @return $this
@@ -57,7 +58,7 @@ class Diff implements RenderInterface {
   /**
    * Gets the left (source) file.
    *
-   * @return \AlexSkrypnyk\File\Internal\ExtendedSplFileInfo
+   * @return \AlexSkrypnyk\File\ExtendedSplFileInfo
    *   The left file.
    */
   public function getLeft(): ExtendedSplFileInfo {
@@ -67,7 +68,7 @@ class Diff implements RenderInterface {
   /**
    * Gets the right (destination) file.
    *
-   * @return \AlexSkrypnyk\File\Internal\ExtendedSplFileInfo
+   * @return \AlexSkrypnyk\File\ExtendedSplFileInfo
    *   The right file.
    */
   public function getRight(): ExtendedSplFileInfo {

--- a/src/Internal/Differ.php
+++ b/src/Internal/Differ.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace AlexSkrypnyk\File\Internal;
 
+use AlexSkrypnyk\File\ExtendedSplFileInfo;
+
 /**
  * Manages file differences between source and destination directories.
  */
@@ -19,7 +21,7 @@ class Differ {
   /**
    * Adds a file from the left (source) directory to the diff collection.
    *
-   * @param \AlexSkrypnyk\File\Internal\ExtendedSplFileInfo $file
+   * @param \AlexSkrypnyk\File\ExtendedSplFileInfo $file
    *   The file to add.
    */
   public function addLeftFile(ExtendedSplFileInfo $file): void {
@@ -30,7 +32,7 @@ class Differ {
   /**
    * Adds a file from the right (destination) directory to the diff collection.
    *
-   * @param \AlexSkrypnyk\File\Internal\ExtendedSplFileInfo $file
+   * @param \AlexSkrypnyk\File\ExtendedSplFileInfo $file
    *   The file to add.
    */
   public function addRightFile(ExtendedSplFileInfo $file): void {

--- a/src/Internal/Index.php
+++ b/src/Internal/Index.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AlexSkrypnyk\File\Internal;
 
+use AlexSkrypnyk\File\ExtendedSplFileInfo;
 use AlexSkrypnyk\File\File;
 
 /**
@@ -18,7 +19,7 @@ class Index {
   /**
    * Files indexed by the path from the base directory.
    *
-   * @var array<string, \AlexSkrypnyk\File\Internal\ExtendedSplFileInfo>|null
+   * @var array<string, \AlexSkrypnyk\File\ExtendedSplFileInfo>|null
    */
   protected ?array $files = NULL;
 

--- a/src/Internal/Patcher.php
+++ b/src/Internal/Patcher.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace AlexSkrypnyk\File\Internal;
 
 use AlexSkrypnyk\File\Exception\PatchException;
+use AlexSkrypnyk\File\ExtendedSplFileInfo;
 use AlexSkrypnyk\File\File;
 
 /**
@@ -61,7 +62,7 @@ class Patcher {
   /**
    * Add a patch file.
    *
-   * @param \AlexSkrypnyk\File\Internal\ExtendedSplFileInfo $file
+   * @param \AlexSkrypnyk\File\ExtendedSplFileInfo $file
    *   The patch file.
    *
    * @return $this

--- a/tests/Unit/DiffTest.php
+++ b/tests/Unit/DiffTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace AlexSkrypnyk\File\Tests\Unit;
 
+use AlexSkrypnyk\File\ExtendedSplFileInfo;
 use AlexSkrypnyk\File\Internal\Diff;
-use AlexSkrypnyk\File\Internal\ExtendedSplFileInfo;
 use AlexSkrypnyk\PhpunitHelpers\UnitTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 

--- a/tests/Unit/ExtendedSplFileInfoTest.php
+++ b/tests/Unit/ExtendedSplFileInfoTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AlexSkrypnyk\File\Tests\Unit;
 
-use AlexSkrypnyk\File\Internal\ExtendedSplFileInfo;
+use AlexSkrypnyk\File\ExtendedSplFileInfo;
 use AlexSkrypnyk\PhpunitHelpers\UnitTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Unit/FileTaskPerformanceTest.php
+++ b/tests/Unit/FileTaskPerformanceTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace AlexSkrypnyk\File\Tests\Unit;
 
+use AlexSkrypnyk\File\ExtendedSplFileInfo;
 use AlexSkrypnyk\File\File;
-use AlexSkrypnyk\File\Internal\ExtendedSplFileInfo;
 use AlexSkrypnyk\PhpunitHelpers\Traits\LoggerTrait;
 use AlexSkrypnyk\PhpunitHelpers\UnitTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/FileTaskTest.php
+++ b/tests/Unit/FileTaskTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace AlexSkrypnyk\File\Tests\Unit;
 
+use AlexSkrypnyk\File\ExtendedSplFileInfo;
 use AlexSkrypnyk\File\File;
-use AlexSkrypnyk\File\Internal\ExtendedSplFileInfo;
 use AlexSkrypnyk\PhpunitHelpers\UnitTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversMethod;

--- a/tests/Unit/IndexTest.php
+++ b/tests/Unit/IndexTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace AlexSkrypnyk\File\Tests\Unit;
 
+use AlexSkrypnyk\File\ExtendedSplFileInfo;
 use AlexSkrypnyk\File\File;
-use AlexSkrypnyk\File\Internal\ExtendedSplFileInfo;
 use AlexSkrypnyk\File\Internal\Index;
 use AlexSkrypnyk\File\Internal\Rules;
 use AlexSkrypnyk\PhpunitHelpers\UnitTestCase;

--- a/tests/Unit/PatcherTest.php
+++ b/tests/Unit/PatcherTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace AlexSkrypnyk\File\Tests\Unit;
 
 use AlexSkrypnyk\File\Exception\PatchException;
+use AlexSkrypnyk\File\ExtendedSplFileInfo;
 use AlexSkrypnyk\File\File;
-use AlexSkrypnyk\File\Internal\ExtendedSplFileInfo;
 use AlexSkrypnyk\File\Internal\Patcher;
 use AlexSkrypnyk\PhpunitHelpers\UnitTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated usage examples in the documentation to reflect a simplified and consolidated import of `ExtendedSplFileInfo` from a new namespace.

- **Refactor**
  - Changed the namespace of `ExtendedSplFileInfo` to make it publicly accessible.
  - Updated all references, type hints, and annotations in the codebase and tests to use the new public namespace for `ExtendedSplFileInfo`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->