### PR TITLE
Added support for ignored paths in assertions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,11 +323,46 @@ class MyTest extends TestCase {
     // Assert directory contains "example" string in at least one file
     $this->assertDirectoryContainsString('/path/to/directory', 'example');
 
+    // Assert directory contains "example" string, ignoring specific files
+    $this->assertDirectoryContainsString('/path/to/directory', 'example', ['temp.log', 'cache']);
+
     // Assert two directories are identical
     $this->assertDirectoryEqualsDirectory('/path/to/dir1', '/path/to/dir2');
   }
 }
 ```
+
+##### Ignoring Paths in Directory Assertions
+
+The directory assertion methods support ignoring specific paths during searches. You can ignore paths in two ways:
+
+1. **Per-method ignoring**: Pass an `$ignored` array parameter to individual assertion methods
+2. **Global ignoring**: Override the `ignoredPath()` method in your test class
+
+```php
+class MyTest extends TestCase {
+  use DirectoryAssertionsTrait;
+
+  // Global ignored paths for all directory assertions in this test class
+  public static function ignoredPath(): array {
+    return ['.git', 'node_modules', 'vendor', 'temp/cache'];
+  }
+
+  public function testWithIgnoredPaths(): void {
+    // This will ignore both global ignored paths AND 'logs' directory
+    $this->assertDirectoryContainsString('/path/to/dir', 'search_term', ['logs']);
+    
+    // Global ignored paths are automatically applied to all directory assertions
+    $this->assertDirectoryNotContainsWord('/path/to/dir', 'forbidden');
+  }
+}
+```
+
+**Important Notes:**
+- Ignored paths are literal subpaths (not wildcard patterns)  
+- Global `ignoredPath()` and per-method `$ignored` parameters are merged together
+- Both file names and directory paths can be ignored
+- Ignored paths are relative to the directory being searched
 
 #### File Assertions Trait
 

--- a/tests/Traits/DirectoryAssertionsTrait.php
+++ b/tests/Traits/DirectoryAssertionsTrait.php
@@ -16,19 +16,40 @@ use AlexSkrypnyk\File\Internal\Index;
 trait DirectoryAssertionsTrait {
 
   /**
+   * Ignored paths for directory assertion operations.
+   *
+   * This method can be overridden in test classes to specify subpaths that
+   * should be ignored during directory content searches. Paths are merged
+   * with any explicitly provided excluded paths in assertion methods.
+   *
+   * Example usage in test class:
+   * ```php
+   * public static function ignoredPath(): array {
+   *   return ['.git', 'node_modules', 'temp/cache'];
+   * }
+   * ```
+   *
+   * @return array
+   *   An array of literal subpaths to ignore during directory assertions.
+   */
+  public static function ignoredPath(): array {
+    return [];
+  }
+
+  /**
    * Assert that a directory contains files with a specific string.
    *
    * @param string $directory
    *   The directory to search in.
    * @param string $needle
    *   The string to search for in files.
-   * @param array $excluded
+   * @param array $ignored
    *   An array of paths to exclude from the search.
    * @param string $message
    *   Optional custom failure message.
    */
-  public function assertDirectoryContainsString(string $directory, string $needle, array $excluded = [], string $message = ''): void {
-    $files = File::containsInDir($directory, $needle, $excluded);
+  public function assertDirectoryContainsString(string $directory, string $needle, array $ignored = [], string $message = ''): void {
+    $files = File::containsInDir($directory, $needle, array_merge(static::ignoredPath(), $ignored));
 
     if (empty($files)) {
       $this->fail($message ?: sprintf('Directory should contain "%s", but it does not.', $needle));
@@ -42,13 +63,13 @@ trait DirectoryAssertionsTrait {
    *   The directory to search in.
    * @param string $needle
    *   The string to search for in files.
-   * @param array $excluded
+   * @param array $ignored
    *   An array of paths to exclude from the search.
    * @param string $message
    *   Optional custom failure message.
    */
-  public function assertDirectoryNotContainsString(string $directory, string $needle, array $excluded = [], string $message = ''): void {
-    $files = File::containsInDir($directory, $needle, $excluded);
+  public function assertDirectoryNotContainsString(string $directory, string $needle, array $ignored = [], string $message = ''): void {
+    $files = File::containsInDir($directory, $needle, array_merge(static::ignoredPath(), $ignored));
 
     if (!empty($files)) {
       $this->fail($message ?: sprintf('Directory should not contain "%s", but it does within files %s.', $needle, implode(', ', $files)));
@@ -65,13 +86,13 @@ trait DirectoryAssertionsTrait {
    *   The directory to search in.
    * @param string $needle
    *   The word to search for in files.
-   * @param array $excluded
+   * @param array $ignored
    *   An array of paths to exclude from the search.
    * @param string $message
    *   Optional custom failure message.
    */
-  public function assertDirectoryContainsWord(string $directory, string $needle, array $excluded = [], string $message = ''): void {
-    $files = File::containsInDir($directory, '/\b' . preg_quote($needle) . '\b/i', $excluded);
+  public function assertDirectoryContainsWord(string $directory, string $needle, array $ignored = [], string $message = ''): void {
+    $files = File::containsInDir($directory, '/\b' . preg_quote($needle) . '\b/i', array_merge(static::ignoredPath(), $ignored));
 
     if (empty($files)) {
       $this->fail($message ?: sprintf('Directory should contain "%s" word, but it does not.', $needle));
@@ -88,13 +109,13 @@ trait DirectoryAssertionsTrait {
    *   The directory to search in.
    * @param string $needle
    *   The word to search for in files.
-   * @param array $excluded
+   * @param array $ignored
    *   An array of paths to exclude from the search.
    * @param string $message
    *   Optional custom failure message.
    */
-  public function assertDirectoryNotContainsWord(string $directory, string $needle, array $excluded = [], string $message = ''): void {
-    $files = File::containsInDir($directory, '/\b' . preg_quote($needle) . '\b/i', $excluded);
+  public function assertDirectoryNotContainsWord(string $directory, string $needle, array $ignored = [], string $message = ''): void {
+    $files = File::containsInDir($directory, '/\b' . preg_quote($needle) . '\b/i', array_merge(static::ignoredPath(), $ignored));
 
     if (!empty($files)) {
       $this->fail($message ?: sprintf('Directory should not contain "%s" word, but it does within files %s.', $needle, implode(', ', $files)));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Directory assertions now support configurable default ignored subpaths (e.g., common folders/files).
  * Explicit ignores provided to assertions are merged with these defaults.
  * Assertion parameter renamed from “excluded” to “ignored” for clarity.

* **Tests**
  * Added tests covering default ignore behavior, class-level overrides, merging with explicit ignores, and contains/not-contains scenarios.

* **Documentation**
  * README updated with examples and rules for per-method and global ignored paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->